### PR TITLE
Fix scrolling CSS for docsearch

### DIFF
--- a/inst/assets/pkgdown.css
+++ b/inst/assets/pkgdown.css
@@ -220,11 +220,6 @@ a.sourceLine:hover {
 
 /* Docsearch -------------------------------------------------------------- */
 
-.ds-dataset-1 {
-  overflow-y: auto!important;
-  max-height: 80vh!important;
-}
-
 .algolia-autocomplete {
   display: block!important;
   -webkit-box-flex: 1;
@@ -255,9 +250,9 @@ a.sourceLine:hover {
 
 .algolia-autocomplete .ds-dropdown-menu [class^=ds-dataset-] {
   padding: 0!important;
-  overflow: visible!important;
   background-color: rgb(255,255,255)!important;
-  border: 0!important
+  border: 0!important;
+  max-height: 80vh;
 }
 
 .algolia-autocomplete .ds-dropdown-menu .ds-suggestions {


### PR DESCRIPTION
https://github.com/r-lib/pkgdown/pull/633 did lose the scrolling fix, but this restores it.

One thing you may want to consider is moving the docsearch section of `inst/templates/head.html` higher up, before the pkgdown.css and extra.css get loaded. A better order of loading assets would probably let you drop the `!important`s, and it would make it easier for pkgdown users to customize the style of the search results panel. 